### PR TITLE
Create BrowserStation auth secret in quickstart

### DIFF
--- a/rayservice.yaml
+++ b/rayservice.yaml
@@ -18,6 +18,11 @@ spec:
             env:
             - name: RAY_memory_usage_threshold
               value: "0.95"
+            - name: BROWSERSTATION_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: browserstation-auth
+                  key: BROWSERSTATION_API_KEY
             ports:
             - containerPort: 8050
               name: http

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -23,6 +23,13 @@ helm repo update
 helm upgrade --install kuberay-operator kuberay/kuberay-operator \
   --namespace ray-system --create-namespace --version 1.3.0 --wait
 
+if [[ $API_KEY ]]; then
+  kubectl create secret generic browserstation-auth \
+    --from-literal=BROWSERSTATION_API_KEY="$API_KEY" \
+    --namespace ray-system \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
 DOCKERFILE=$(
   [[ $ARCH == arm64 && -f Dockerfile.arm ]] && echo Dockerfile.arm \
   || echo Dockerfile.$ARCH


### PR DESCRIPTION
Adds the BrowserStation API key Kubernetes secret during quickstart so rayservice.yaml can resolve BROWSERSTATION_API_KEY when gateway auth is enabled.

Acceptance criteria:
- [x] quickstart creates/updates browserstation-auth before applying rayservice.yaml
- [x] bash -n scripts/quickstart.sh passes